### PR TITLE
fix for nomad install

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @robmorgan @Etiene @anouarchattouna
+* @copernicium-112

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ data-center aware scheduler. A Nomad cluster typically includes a small number o
 for being part of the [consensus protocol](https://www.nomadproject.io/docs/internals/consensus.html), and a larger
 number of client nodes, which are used for running jobs.
 
+Since the base repository has been archived, this fork has been enhanced with additional features including support for bootstrapping the Nomad cluster with ACL, policy, and token management, node class options to categorize the type of clients available, and more.
+
 ![Nomad architecture](https://raw.githubusercontent.com/hashicorp/terraform-aws-nomad/master/_docs/architecture.png)
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# DISCLAIMER: This is no longer supported.
-Moving forward in the future this repository will be no longer supported and eventually lead to
-deprecation. Please use our latest versions of our products moving forward or alternatively you
-may fork the repository to continue use and development for your personal/business use.
-
----
 <!--
 :type: service
 :name: HashiCorp Nomad
@@ -37,17 +31,17 @@ number of client nodes, which are used for running jobs.
 * Supports colocated clusters and separate clusters
 * Least privilege security group rules for servers
 * Auto scaling and Auto healing
+* Support for bootstrapping the Nomad cluster with ACL, policy, and token management.
+* Node class options to categorize the type of clients available.
 
 
 
 
 ## Learn
 
-This repo was created by [Gruntwork](https://www.gruntwork.io?ref=repo_aws_nomad), and follows the same patterns as [the Gruntwork
-Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), a collection of reusable,
-battle-tested, production ready infrastructure code. You can read [How to use the Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library/) for an overview
-of how to use modules maintained by Gruntwork!
+This repo was originally created by [Gruntwork](https://www.gruntwork.io?ref=repo_aws_nomad) and follows the same patterns as [the Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), a collection of reusable, battle-tested, production-ready infrastructure code. You can read [How to use the Gruntwork Infrastructure as Code Library](https://gruntwork.io/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library/) for an overview of how to use modules maintained by Gruntwork.
+
+Since the base repository has been archived, this fork has been enhanced with additional features including support for bootstrapping the Nomad cluster with ACL, policy and token management, node class options to categorize the type of clients available, and more.
 
 ### Core concepts
 
@@ -59,10 +53,10 @@ of how to use modules maintained by Gruntwork!
 
 ### Repo organization
 
-* [modules](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
-* [examples](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples): This folder contains working examples of how to use the submodules.
-* [test](https://github.com/hashicorp/terraform-aws-nomad/tree/master/test): Automated tests for the modules and examples.
-* [root](https://github.com/hashicorp/terraform-aws-nomad/tree/master): The root folder is *an example* of how to use the [nomad-cluster module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster) module to deploy a [Nomad](https://www.nomadproject.io/) cluster in [AWS](https://aws.amazon.com/). The Terraform Registry requires the root of every repo to contain Terraform code, so we've put one of the examples there. This example is great for learning and experimenting, but for production use, please use the underlying modules in the [modules folder](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules) directly.
+* [modules](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+* [examples](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/examples): This folder contains working examples of how to use the submodules.
+* [test](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/test): Automated tests for the modules and examples.
+* [root](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master): The root folder is *an example* of how to use the [nomad-cluster module](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules/nomad-cluster) module to deploy a [Nomad](https://www.nomadproject.io/) cluster in [AWS](https://aws.amazon.com/). The Terraform Registry requires the root of every repo to contain Terraform code, so we've put one of the examples there. This example is great for learning and experimenting, but for production use, please use the underlying modules in the [modules folder](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules) directly.
 
 
 
@@ -75,7 +69,7 @@ of how to use modules maintained by Gruntwork!
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-* [examples folder](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+* [examples folder](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -91,24 +85,27 @@ If you want to deploy this repo in production, check out the following resources
 ### Day-to-day operations
 
 * [How to deploy Nomad and Consul in the same
-  cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/core-concepts.md#deploy-nomad-and-consul-in-the-same-cluster)
+  cluster](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/core-concepts.md#deploy-nomad-and-consul-in-the-same-cluster)
 * [How to deploy Nomad and Consul in separate
-  clusters](https://github.com/hashicorp/terraform-aws-nomad/tree/master/core-concepts.md#deploy-nomad-and-consul-in-separate-clusters)
-* [How to connect to the Nomad cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster/README.md#how-do-you-connect-to-the-nomad-cluster)
-* [What happens if a node crashes](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster/README.md#what-happens-if-a-node-crashes)
-* [How to connect load balancers to the ASG](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster/README.md#how-do-you-connect-load-balancers-to-the-auto-scaling-group-asg)
+  clusters](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/core-concepts.md#deploy-nomad-and-consul-in-separate-clusters)
+* [How to connect to the Nomad cluster](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules/nomad-cluster/README.md#how-do-you-connect-to-the-nomad-cluster)
+* [What happens if a node crashes](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules/nomad-cluster/README.md#what-happens-if-a-node-crashes)
+* [How to connect load balancers to the ASG](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules/nomad-cluster/README.md#how-do-you-connect-load-balancers-to-the-auto-scaling-group-asg)
 
 ### Major changes
 
-* [How to upgrade a Nomad cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster/README.md#how-do-you-roll-out-updates)
+* [How to upgrade a Nomad cluster](https://github.com/copernicium-112/terraform-aws-nomad-acl/tree/master/modules/nomad-cluster/README.md#how-do-you-roll-out-updates)
 
 ## Who created this Module?
 
-These modules were created by [Gruntwork](http://www.gruntwork.io/?ref=repo_aws_nomad), in partnership with HashiCorp, in 2017 and maintained through 2021. They were deprecated in 2022, see the top of the README for details.
+These modules were created by [Gruntwork](http://www.gruntwork.io/?ref=repo_aws_nomad), in partnership with HashiCorp, in 2017 and maintained through 2021. They were deprecated in 2022.
+
+Since the base repository has been archived, this fork has been enhanced with additional features including support for bootstrapping the Nomad cluster with ACL, policy and token management, node class options to categorize the type of clients available, and more.
 
 ## License
 
 Please see [LICENSE](https://github.com/hashicorp/terraform-aws-nomad/tree/master/LICENSE) for details on how the code in this repo is licensed.
 
+Modifications and additional features were added by [copernicium-112](https://github.com/copernicium-112)
 
 Copyright &copy; 2019 [Gruntwork](https://www.gruntwork.io?ref=repo_aws_nomad), Inc.

--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -165,7 +165,7 @@ function install_binaries {
 
   log_info "Downloading Nomad $version from $url to $download_path"
   curl -o "$download_path" "$url"
-  unzip -d /tmp "$download_path"
+  unzip -o -d /tmp "$download_path"
 
   log_info "Moving Nomad binary to $nomad_dest_path"
   sudo mv "/tmp/nomad" "$nomad_dest_path"


### PR DESCRIPTION
From version 1.7.0 or later, LICENSE.txt is included in the package, which could collide with the existing one if any already present in /tmp