### PR TITLE
Correct instance availability zone variable in run-nomad script

### DIFF
--- a/modules/run-nomad/run-nomad
+++ b/modules/run-nomad/run-nomad
@@ -286,7 +286,7 @@ function generate_nomad_config {
   instance_id=$(get_instance_id "$metadata_token")
   instance_ip_address=$(get_instance_ip_address "$metadata_token")
   instance_region=$(get_instance_region "$metadata_token")
-  availability_zone=$(get_instance_availability_zone "$metadata_token")
+  instance_availability_zone=$(get_instance_availability_zone "$metadata_token")
 
   local server_config=""
   if [[ "$server" == "true" ]]; then
@@ -420,7 +420,7 @@ EOF
 
   log_info "Creating default Nomad config file in $config_path"
   cat >"$config_path" <<EOF
-datacenter = "$availability_zone"
+datacenter = "$instance_availability_zone"
 name       = "$node_name"
 region     = "$instance_region"
 bind_addr  = "0.0.0.0"


### PR DESCRIPTION
## Summary
- fix datacenter configuration by using instance availability zone variable

## Testing
- `pre-commit run --show-diff-on-failure --color=always`
- `cd test && go test -v ./...` *(fails: Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables...)*

------
https://chatgpt.com/codex/tasks/task_e_6895a4c606e083288b869e1404fe1aff